### PR TITLE
 query enable passing in query as list object for canonical arg

### DIFF
--- a/R/redshift.r
+++ b/R/redshift.r
@@ -23,5 +23,5 @@ redshift.columns <- function(conn, tableName) {
 }
 
 redshift.query <- function(conn, ...) {
-  dbGetQuery(conn, paste(...))
+  dbGetQuery(conn, paste(..., collapse=' ', sep=' '))
 }


### PR DESCRIPTION
allows both query argument format
- `redshift.query(conn, c('SELECT *', 'FROM tb'))` (which I prefer)
- `redshift.query(conn, 'SELECT *', 'FROM tb')` (which you like)
