### PR TITLE
Correct parameters list for columns functions

### DIFF
--- a/R/redshift.r
+++ b/R/redshift.r
@@ -26,7 +26,7 @@ redshift.tables <- function(conn, schema='public') {
   dbGetQuery(conn, sql)
 }
 
-redshift.columns <- function(conn, schema='public', tableName) {
+redshift.columns <- function(conn, tableName, schema='public') {
   sql <- paste0("SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_schema = '", schema, "' AND table_name ='", tableName, "';")
   dbGetQuery(conn, sql)
 }

--- a/man/redshift.columns.Rd
+++ b/man/redshift.columns.Rd
@@ -7,12 +7,12 @@ Columns in Redshift table
 Provides metadata about the columns available within a Redshift table
 }
 \usage{
-redshift.columns(conn, schema='public', tableName)
+redshift.columns(conn, tableName, schema='public')
 }
 \arguments{
   \item{conn}{The RJDBC connection object created with \link{redshift.connect}}
-  \item{schema}{The schema name}
   \item{tableName}{Table name as a string}
+  \item{schema}{The schema name}
 }
 \value{
 Returns a dataframe listing: column name, data type, nullable.


### PR DESCRIPTION
redshift.columns parameters list is incorrect if we want to take advantage of the default schema value without have to use named variable.
Move the schema variable to be the last in the list fixed the problem.
