### PR TITLE
support role-based access control in redshift.unload()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: redshift
 Type: Package
 Title: Easier access to AWS Redshift clusters
-Version: 0.4
+Version: 0.5
 Date: 2013-04-30
 Author: Paul Ingles
 Maintainer: Paul Ingles <paul@oobaloo.co.uk>

--- a/R/redshift.r
+++ b/R/redshift.r
@@ -39,12 +39,19 @@ redshift.submitquery <- function(conn, ...) {
   dbSendUpdate(conn, paste(..., collapse=' ', sep=' '))
 }
 
-redshift.unload <- function(conn, query, filename, aws.accesskey, aws.secretkey, delim = ',', 
-                            allowOverwrite = TRUE, parallel = TRUE, zip = TRUE, addquotes = FALSE){
+redshift.unload <- function(conn, query, filename, aws.accesskey = '', aws.secretkey = '', delim = ',',
+                            allowOverwrite = TRUE, parallel = TRUE, zip = TRUE, addquotes = FALSE, aws.role = ''){
   query = gsub("'","''",query)
   sql = paste0("('",gsub(";","",query),"')")
   loc = paste0("'",filename,"'")
-  cred = paste0("'aws_access_key_id=",aws.accesskey,";aws_secret_access_key=",aws.secretkey,"'")
+  if (aws.role != '') {
+      cred = paste0("'aws_iam_role=",aws.role,"'")
+  } else if (aws.accesskey != '' && aws.secretkey != '') {
+      cred = paste0("'aws_access_key_id=",aws.accesskey,";aws_secret_access_key=",aws.secretkey,"'")
+      warning("AWS recommend role-based access control: http://docs.aws.amazon.com/redshift/latest/dg/copy-usage_notes-access-permissions.html#copy-usage_notes-access-role-based")
+  } else {
+      stop("aws.accesskey and aws.secretkey, or aws.role must be set")
+  }
   delimiter = paste0("'",delim,"'")
   if(!parallel) par = "PARALLEL OFF" else par = ""
   if(!zip) gzip = "" else gzip = "GZIP"

--- a/man/redshift.unload.Rd
+++ b/man/redshift.unload.Rd
@@ -5,18 +5,38 @@
 Unloads a redshift query to the AWS S3 cloud
 }
 \usage{
-redshift.unload(conn, query, filename, aws.accesskey, aws.secretkey, delim = ',', allowOverwrite = TRUE, parallel = TRUE, zip = TRUE)
+redshift.unload(conn, query, filename,
+ aws.accesskey = '', aws.secretkey = '',
+ delim = ',',
+ allowOverwrite = TRUE,
+ parallel = TRUE,
+ zip = TRUE,
+ addquotes = FALSE,
+ aws.role = ''
+)
 }
 \arguments{
   \item{conn}{The database connection}
   \item{query}{The Query to be unloaded}
   \item{filename}{The destination file path and name}
-  \item{aws.accesskey}{The AWS Access Key}
-  \item{aws.secretkey}{The AWS Secret Key}
+  \item{aws.accesskey}{The AWS Access Key. Defaults to '' but see note.}
+  \item{aws.secretkey}{The AWS Secret Key. Defaults to '' but see note.}
   \item{delim}{The Delimiter to be used. Defaults to ','}
   \item{allowOverwrite}{Logical. Allow Redshift to overwrite existing files with same name? Defaults to TRUE.}
   \item{parallel}{Logical. Allow Redshift to run parallelqueries and create multiple files? Defaults to TRUE.}
   \item{zip}{Logical. Allow Redshift to dump a zipped file? Defaults to TRUE.}
+  \item{addquotes}{Logical. Wrap quotations marks around wach field. Defaults to TRUE.}
+  \item{aws.role}{The AWS Role. Defaults to '' but see note.}
+}
+\note{
+Specify \emph{either}
+  \itemize{
+    \item \code{aws.access} and \code{aws.secret} \emph{OR}
+    \item \code{aws.role}
+  }
+
+  Role-based access is recommended -- see
+  \url{http://docs.aws.amazon.com/redshift/latest/dg/copy-usage_notes-access-permissions.html#copy-usage_notes-access-role-based}
 }
 \value{
 NA
@@ -27,7 +47,7 @@ Eeshan Chatterjee
 \examples{
 require(redshift)
 # conn <- redshift.connect("jdbc:postgresql://blah.blah.eu-west-1.redshift.amazonaws.com:5439/data", "username", "password")
-#redshift.unload(conn,query = "SELECT * from mytable where name like 'Eeshan'",filename = "s3://Eeshan/files/test.txt",aws.accesskey = <AWS #Access Key>,aws.secretkey = <AWS Secret Key>,delim = ",",parallel = F)
+#redshift.unload(conn,query = "SELECT * from mytable where name like 'Eeshan'",filename = "s3://Eeshan/files/test.txt",aws.accesskey = <AWS Access Key>,aws.secretkey = <AWS Secret Key>,delim = ",",parallel = F)
+#redshift.unload(conn,query = "SELECT * from mytable where name like 'Richard'",filename = "s3://Richard/files/test.txt",aws.role = <AWS Role>,delim = ",",parallel = F)
 }
 \keyword{ unload }
-


### PR DESCRIPTION
Managed to maintain backward compatibility, so I don't think there's a need to alter the major version number (currently at zero!)

cheers
Richard